### PR TITLE
Update Toyota Yaris generations: Add Wikipedia reference and correct start date

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # Toyota Yaris
 
+This repository contains signal set configurations for the Toyota Yaris, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Toyota Yaris.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,6 +1,9 @@
+references:
+  - "https://en.wikipedia.org/wiki/Toyota_Yaris"
+
 generations:
   - name: "First Generation (XP10)"
-    start_year: 1999
+    start_year: 1998
     end_year: 2005
     description: "The first-generation Toyota Yaris (marketed as the Echo in North America and the Vitz in Japan) was introduced as Toyota's new global subcompact car, replacing the Tercel/Starlet in various markets. Featuring distinctive, somewhat polarizing styling with a tall, rounded profile maximizing interior space within minimal exterior dimensions, the original Yaris established a design philosophy prioritizing interior packaging efficiency. Available in three-door and five-door hatchback configurations plus a sedan variant (primarily for North America), the Yaris was powered by a range of small-displacement engines including 1.0, 1.3, and 1.5-liter units, paired with either manual or automatic transmissions. The interior featured an unconventional center-mounted instrument cluster and surprisingly spacious accommodations given the compact exterior, with clever storage solutions and flexible seating arrangements. Safety features were relatively advanced for the segment and era, with available ABS and multiple airbags. This generation successfully established the Yaris/Echo/Vitz as Toyota's entry-level global offering, appealing to buyers seeking efficiency, value, and Toyota's reputation for reliability in a compact package, though the North American Echo variant faced criticism for its unconventional styling and sparse standard equipment."
 


### PR DESCRIPTION
- Added references array with Toyota Yaris Wikipedia URL
- Updated first generation start year from 1999 to 1998 based on Wikipedia production timeline (Dec 15, 1998)
- Retained detailed generation descriptions for XP10, XP90, XP130, and XP210 platforms
- Updated README.md with standard template

Wikipedia evidence: First generation production began December 15, 1998
